### PR TITLE
Fix missing page events for first page

### DIFF
--- a/Sources/PagedPublication/PagedPublicationView.swift
+++ b/Sources/PagedPublication/PagedPublicationView.swift
@@ -351,6 +351,17 @@ public class PagedPublicationView: UIView {
                 lifecycleEventTracker = PagedPublicationView.LifecycleEventTracker(publicationModel: publicationModel, eventHandler: eventHandler)
                 lifecycleEventTracker?.opened()
                 lifecycleEventTracker?.didAppear()
+                
+                // page has already been changed selected before load, so make a new spread tracker, and register page-loads if they already have been loaded
+                if self.currentPageIndexes.count > 0 {
+                    lifecycleEventTracker?.newSpreadLifecycleTracker(for: self.currentPageIndexes)
+                    
+                    currentPageIndexes.forEach {
+                        if let pageView = self.contentsView.versoView.getPageViewIfLoaded($0) as? PagedPublicationView.PageView, pageView.isViewImageLoaded {
+                            lifecycleEventTracker?.spreadLifecycleTracker?.pageLoaded(pageIndex: $0)
+                        }
+                    }
+                }
             }
             
             delegate?.didLoad(publication: publicationModel, in: self)


### PR DESCRIPTION
The issue is caused when the `page changed` callback is triggered before publication is loaded. This means it tries to create a newSpreadLifecycleTracker before there is a lifecycleEventTracker to save it into, meaning that the first spread's events are lost. Now we also create a new spreadLifecycle tracker on load, to mitigate this situation.