### PR TITLE
IncitoOpened event - v2

### DIFF
--- a/Demos/SharedSource/DemoIncitoViewController.swift
+++ b/Demos/SharedSource/DemoIncitoViewController.swift
@@ -20,8 +20,6 @@ class DemoIncitoViewController: IncitoLoaderViewController {
     }
     
     func load(publication: CoreAPI.PagedPublication) {
-        guard let incitoId = publication.incitoId else { return }
-    
         self.title = publication.branding.name
         
         // Note: we are setting the `backgroundColor` on the View Controller (rather than `incitoVC.view.backgroundColor`)
@@ -30,10 +28,7 @@ class DemoIncitoViewController: IncitoLoaderViewController {
         
         // Start the actual loading of the incito.
         // By providing the related publicationId we can more accurately measure incito-read analytics
-        self.load(
-            graphId: incitoId,
-            relatedPublicationId: publication.id
-        )
+        super.load(publication: publication)
     }
 }
 

--- a/Sources/EventsTracker/Event+SDKEvents.swift
+++ b/Sources/EventsTracker/Event+SDKEvents.swift
@@ -23,9 +23,11 @@ extension Event {
         case searched                       = 5
         case firstOfferOpenedAfterSearch    = 6
         case offerOpenedAfterSearch         = 7
+        @available(*, deprecated, renamed: "incitoPublicationOpened_v2")
         case incitoPublicationOpened        = 8
         case searchResultsViewed            = 9
         case potentialLocalBusinessVisit    = 10
+        case incitoPublicationOpened_v2     = 11
     }
     
     /**
@@ -208,6 +210,7 @@ extension Event {
      - parameter timestamp: The date that the event occurred. Defaults to now.
      - parameter tokenizer: A Tokenizer for generating the unique view token. Defaults to the shared EventsTrackers's viewTokenizer.
      */
+    @available(*, deprecated, renamed: "incitoPublicationOpened(_:isAlsoPagedPublication:timestamp:tokenizer:)")
     internal static func incitoPublicationOpened(
         _ incitoId: IncitoGraphIdentifier,
         pagedPublicationId: PagedPublicationCoreAPIIdentifier?,
@@ -225,6 +228,26 @@ extension Event {
         if let pagedPubId = pagedPublicationId {
             event = event.addingViewToken(content: pagedPubId.rawValue, key: "pp.vt", tokenizer: tokenizer)
         }
+        
+        return event
+    }
+    
+    internal static func incitoPublicationOpened(
+        _ incitoPublicationId: PagedPublicationCoreAPIIdentifier,
+        isAlsoPagedPublication: Bool,
+        timestamp: Date = Date(),
+        tokenizer: Tokenizer = EventsTracker.shared.viewTokenizer.tokenize
+        ) -> Event {
+        
+        let payload: PayloadType = [
+            "ip.id": .string(incitoPublicationId.rawValue),
+            "ip.paged": .bool(isAlsoPagedPublication)
+        ]
+        
+        let event = Event(timestamp: timestamp,
+                          type: EventType.incitoPublicationOpened_v2.rawValue,
+                          payload: payload)
+            .addingViewToken(content: incitoPublicationId.rawValue, tokenizer: tokenizer)
         
         return event
     }
@@ -328,6 +351,7 @@ extension Event {
         return offerOpenedAfterSearch(offerId: offerId, query: query, languageCode: languageCode, timestamp: Date())
     }
     
+    @available(*, deprecated, renamed: "incitoPublicationOpened(_:isAlsoPagedPublication:)")
     public static func incitoPublicationOpened(
         _ incitoId: IncitoGraphIdentifier,
         pagedPublicationId: PagedPublicationCoreAPIIdentifier?
@@ -335,6 +359,17 @@ extension Event {
         return incitoPublicationOpened(
             incitoId,
             pagedPublicationId: pagedPublicationId,
+            timestamp: Date()
+        )
+    }
+    
+    public static func incitoPublicationOpened(
+        _ incitoPublicationId: PagedPublicationCoreAPIIdentifier,
+        isAlsoPagedPublication: Bool
+        ) -> Event {
+        return incitoPublicationOpened(
+            incitoPublicationId,
+            isAlsoPagedPublication: isAlsoPagedPublication,
             timestamp: Date()
         )
     }

--- a/Sources/IncitoPublication/IncitoLoaderViewController+GraphLoader.swift
+++ b/Sources/IncitoPublication/IncitoLoaderViewController+GraphLoader.swift
@@ -139,7 +139,7 @@ extension IncitoLoaderViewController {
         completion: ((Result<(viewController: IncitoViewController, firstSuccessfulLoad: Bool), Error>) -> Void)? = nil
         ) {
         
-        // if the publication doesnt have a graphId, then just 
+        // if the publication doesnt have a graphId, then just eject with an error
         guard let graphId = publication.incitoId else {
             self.load(IncitoLoader(value: .failure(IncitoPublicationLoaderError.notAnIncitoPublication))) { vcResult in
                 completion?(vcResult.map({ ($0, false) }))


### PR DESCRIPTION
- Use the new version off the IncitoOpened event. 
- Deprecate the old event. 
- Modify the 'load' interface to require a coreId to be used when loading.