### PR TITLE
Fix multi-longpress

### DIFF
--- a/Sources/ShopGunSDK/PagedPublication/PagedPublicationView+HotspotOverlayView.swift
+++ b/Sources/ShopGunSDK/PagedPublication/PagedPublicationView+HotspotOverlayView.swift
@@ -128,8 +128,6 @@ extension PagedPublicationView {
             doubleTapGesture!.numberOfTapsRequired = 2
             doubleTapGesture!.delegate = self
             
-            tapGesture?.require(toFail: longPressGesture!)
-            
             addGestureRecognizer(longPressGesture!)
             addGestureRecognizer(tapGesture!)
             addGestureRecognizer(touchGesture!)


### PR DESCRIPTION
Currently if you try to perform multiple long-presses rapidly & repeatedly, only the first will register. This fixes that (the second long press was being blocked by the tap gesture)